### PR TITLE
Fix Eigen includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package (Matio REQUIRED)
 find_package (HDF5 REQUIRED)
 
 include_directories(include)
-include_directories (${EIGEN3_INCLUDE_DIRS})
+include_directories (${EIGEN3_INCLUDE_DIR})
 include_directories (${MATIO_INCLUDE_DIRS})
 
 if(BUILD_TESTS)

--- a/tests/read_test.cpp
+++ b/tests/read_test.cpp
@@ -6,8 +6,8 @@
 #include <vector>
 #include <complex>
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Core>
+#include <Eigen/Dense>
 #include <iostream>
 #include <MATio/MATio.hpp>
 #include <map>


### PR DESCRIPTION
This corrects the usage of the FindEigen.cmake script and the inclusion of Eigen in the test.
